### PR TITLE
MARP-1174 Fix various styling issues of buttons and dropdowns

### DIFF
--- a/marketplace-ui/src/app/core/interceptors/api.interceptor.ts
+++ b/marketplace-ui/src/app/core/interceptors/api.interceptor.ts
@@ -45,7 +45,7 @@ export const apiInterceptor: HttpInterceptorFn = (req, next) => {
   return next(cloneReq).pipe(
     catchError(error => {
       if (ERROR_CODES.includes(error.status)) {
-        router.navigate([`${ERROR_PAGE_PATH}/error.status`]);
+        router.navigate([`${ERROR_PAGE_PATH}/${error.status}`]);
       } else {
         router.navigate([ERROR_PAGE_PATH]);
       }

--- a/marketplace-ui/src/app/modules/product/product-detail/product-detail-version-action/product-detail-version-action.component.html
+++ b/marketplace-ui/src/app/modules/product/product-detail/product-detail-version-action/product-detail-version-action.component.html
@@ -1,6 +1,6 @@
 @switch (actionType) {
   @case ('standard') {
-    <div class="install-download-button-container gap-2 w-100 d-flex d-lg-block">
+    <div class="install-download-button-container gap-2 w-100 d-flex">
       <button [lang]="languageService.selectedLanguage()" class="btn btn__install flex-grow-1 me-lg-2" data-bs-toggle="tooltip"
               data-bs-placement="bottom" data-bs-html="true" data-bs-title="<p class='text-primary'>
               Please open the

--- a/marketplace-ui/src/app/modules/product/product-detail/product-detail-version-action/product-detail-version-action.component.html
+++ b/marketplace-ui/src/app/modules/product/product-detail/product-detail-version-action/product-detail-version-action.component.html
@@ -24,7 +24,7 @@
       </button>
       
       @if (isDropDownDisplayed()) {
-        <div #artifactDownloadDialog class="dropdown-menu show maven-artifact-version__action border__dropdown">
+        <div #artifactDownloadDialog id="download-dropdown-menu" class="show maven-artifact-version__action border__dropdown">
           <div class="up-arrow border__dropdown position-absolute"></div>
           <form>
             <div class="form-group">

--- a/marketplace-ui/src/app/modules/product/product-detail/product-detail-version-action/product-detail-version-action.component.scss
+++ b/marketplace-ui/src/app/modules/product/product-detail/product-detail-version-action/product-detail-version-action.component.scss
@@ -98,8 +98,10 @@
   line-height: 16.8px;
 }
 
-::ng-deep .dropdown-menu.menu-bar {
-  margin-top: 2.5rem;
+::ng-deep #download-dropdown-menu .dropdown-menu.menu-bar {
+  margin-top: 0.2rem;
+  height: fit-content;
+  max-height: 176px;
 }
 
 ::ng-deep .install-designer-dropdown {
@@ -116,7 +118,7 @@
   border: 0.5px solid #ebebeb;
 }
 
-::ng-deep .dropdown-menu {
+::ng-deep #download-dropdown-menu {
   position: absolute;
   right: 0;
   width: 400px;
@@ -128,8 +130,11 @@
   border-radius: 5px;
   box-shadow: 0px 4px 30px 0px rgba(0, 0, 0, 0.1);
 
-  @media screen and (max-width: 991px) {
+  @media (max-width: 1399px) {
     width: 100%;
+  }
+
+  @media (max-width: 991px) {
     margin-top: 4rem;
   }
 

--- a/marketplace-ui/src/app/modules/product/product-detail/product-detail-version-action/product-detail-version-action.component.scss
+++ b/marketplace-ui/src/app/modules/product/product-detail/product-detail-version-action/product-detail-version-action.component.scss
@@ -123,7 +123,7 @@
   right: 0;
   width: 400px;
   height: 204px;
-  margin-top: 1rem;
+  margin-top: 4rem;
   background-color: var(--bs-body-bg);
   z-index: 999;
   padding: 10px;
@@ -132,10 +132,6 @@
 
   @media (max-width: 1399px) {
     width: 100%;
-  }
-
-  @media (max-width: 991px) {
-    margin-top: 4rem;
   }
 
   &.maven-artifact-version__action {
@@ -197,8 +193,19 @@
   border-bottom-color: transparent;
   background-color: var(--bs-body-bg);
 
-  @media screen and (max-width: 991px) {
-    right: 22%;
+  @media screen and (max-width: 1399px) {
+    right: 14%;
+  }
+  @media screen and (max-width: 1199px) {
+    right: 21%;
+  }
+
+  @media screen and (max-width: 767px) {
+    right: 18%;
+  }
+
+  @media screen and (max-width: 575px) {
+    right: 15%;
   }
 }
 

--- a/marketplace-ui/src/app/modules/product/product-detail/product-detail-version-action/product-detail-version-action.component.scss
+++ b/marketplace-ui/src/app/modules/product/product-detail/product-detail-version-action/product-detail-version-action.component.scss
@@ -196,6 +196,7 @@
   @media screen and (max-width: 1399px) {
     right: 14%;
   }
+  
   @media screen and (max-width: 1199px) {
     right: 21%;
   }

--- a/marketplace-ui/src/app/modules/product/product-detail/product-detail-version-action/product-detail-version-action.component.ts
+++ b/marketplace-ui/src/app/modules/product/product-detail/product-detail-version-action/product-detail-version-action.component.ts
@@ -11,7 +11,6 @@ import {
   Output,
   Signal,
   signal,
-  ViewChild,
   WritableSignal
 } from '@angular/core';
 import { ThemeService } from '../../../../core/services/theme/theme.service';

--- a/marketplace-ui/src/app/modules/product/product-detail/product-detail.component.html
+++ b/marketplace-ui/src/app/modules/product/product-detail/product-detail.component.html
@@ -85,99 +85,99 @@
       <div
         class="tab-group d-flex flex-column justify-content-center align-items-start p-0 col-12 col-xl-8">
         @if (displayedTabsSignal().length > 0) {
-        <div class="row-tab d-none d-xl-block col-12">
-          <ul ngbNav class="nav nav-tabs form-tabs">
-            @for (displayedTab of displayedTabsSignal(); track $index) {
-              <li
-                ngbNavItem
-                class="nav-item d-flex flex-row position-relative border-bottom-1 p-2 justify-content-center align-items-start">
-                <a
-                  [lang]="languageService.selectedLanguage()"
-                  ngbNavLink
-                  class="nav-link tab-title border-0 bg-transparent"
-                  [class.active]="activeTab === displayedTab.value"
-                  [id]="displayedTab.tabId"
-                  (click)="setActiveTab(displayedTab.value)"
-                  role="tab"
-                  [ngClass]="{
-                    'text-secondary': themeService.isDarkMode(),
-                    'text-dark': !themeService.isDarkMode()
-                  }">
-                  {{ displayedTab.label | translate }}
-                </a>
-              </li>
-            }
-          </ul>
-        </div>
-        <!-- For smaller screens -->
-        <div
-          class="dropdown-tab d-block d-xl-none d-flex flex-row justify-content-center align-items-center w-100">
-          <div class="dropdown-row flex-row align-items-center w-100">
-            <div
-              class="dropdown-container position-relative d-flex align-items-center w-100">
-              <div id="tab-group-dropdown" class="flex-grow-1 w-100">
-                <app-common-dropdown
-                  [items]="displayedTabsSignal()"
-                  [selectedItem]="getSelectedTabLabel() | translate"
-                  buttonClass="form-select flex-grow-1 text-start"
-                  (itemSelected)="onTabChange($event.value)">
-                </app-common-dropdown>
-              </div>
-
-              <button
-                class="bg-transparent border-0"
-                (click)="onShowInfoContent()">
-                <i
-                  class="info-icon bi bi-info-circle"
-                  [ngClass]="{
-                    'text-primary': themeService.isDarkMode(),
-                    'text-secondary':
-                      themeService.isDarkMode() && isDropdownOpen(),
-                    'text-dark': !themeService.isDarkMode()
-                  }"></i>
-              </button>
+          <div class="row-tab d-none d-xl-block col-12">
+            <ul ngbNav class="nav nav-tabs form-tabs">
+              @for (displayedTab of displayedTabsSignal(); track $index) {
+                <li
+                  ngbNavItem
+                  class="nav-item d-flex flex-row position-relative border-bottom-1 p-2 justify-content-center align-items-start">
+                  <a
+                    [lang]="languageService.selectedLanguage()"
+                    ngbNavLink
+                    class="nav-link tab-title border-0 bg-transparent"
+                    [class.active]="activeTab === displayedTab.value"
+                    [id]="displayedTab.tabId"
+                    (click)="setActiveTab(displayedTab.value)"
+                    role="tab"
+                    [ngClass]="{
+                      'text-secondary': themeService.isDarkMode(),
+                      'text-dark': !themeService.isDarkMode()
+                    }">
+                    {{ displayedTab.label | translate }}
+                  </a>
+                </li>
+              }
+            </ul>
+          </div>
+          <!-- For smaller screens -->
+          <div
+            class="dropdown-tab d-block d-xl-none d-flex flex-row justify-content-center align-items-center w-100">
+            <div class="dropdown-row flex-row align-items-center w-100">
               <div
-                class="info-dropdown w-100"
-                [ngClass]="{
-                  show: isDropdownOpen()
-                }">
-                <app-product-detail-information-tab
-                  [productDetail]="productDetail()"
-                  [selectedVersion]="
-                    selectedVersion
-                  "></app-product-detail-information-tab>
+                class="dropdown-container position-relative d-flex align-items-center w-100">
+                <div id="tab-group-dropdown" class="flex-grow-1 w-100">
+                  <app-common-dropdown
+                    [items]="displayedTabsSignal()"
+                    [selectedItem]="getSelectedTabLabel() | translate"
+                    buttonClass="form-select flex-grow-1 text-start"
+                    (itemSelected)="onTabChange($event.value)">
+                  </app-common-dropdown>
+                </div>
+
+                <button
+                  class="bg-transparent border-0"
+                  (click)="onShowInfoContent()">
+                  <i
+                    class="info-icon bi bi-info-circle"
+                    [ngClass]="{
+                      'text-primary': themeService.isDarkMode(),
+                      'text-secondary':
+                        themeService.isDarkMode() && isDropdownOpen(),
+                      'text-dark': !themeService.isDarkMode()
+                    }"></i>
+                </button>
+                <div
+                  class="info-dropdown w-100"
+                  [ngClass]="{
+                    show: isDropdownOpen()
+                  }">
+                  <app-product-detail-information-tab
+                    [productDetail]="productDetail()"
+                    [selectedVersion]="
+                      selectedVersion
+                    "></app-product-detail-information-tab>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-        <div class="tab-content col-12 default-cursor">
-          @if (!isEmptyProductContent()) {
-            @for (displayedTab of displayedTabsSignal(); track $index) {
-              <div
-                class="tab-pane fade show"
-                [class.active]="activeTab === displayedTab.value"
-                [id]="displayedTab.value"
-                role="tabpanel"
-                [attr.aria-labelledby]="displayedTab.value + '-tab'">
-                @if (displayedTab.value === 'dependency') {
-                  <app-product-detail-maven-content
-                    [productDetail]="productDetail()"
-                    [selectedVersion]="selectedVersion">
-                  </app-product-detail-maven-content>
-                } @else {
-                  <markdown
-                    [lang]="languageService.selectedLanguage()"
-                    class="readme-content"
-                    [data]="
-                      getProductModuleContentValue(displayedTab)
-                        | multilingualism: languageService.selectedLanguage()
-                    "></markdown>
-                }
-              </div>
+          <div class="tab-content col-12 default-cursor">
+            @if (!isEmptyProductContent()) {
+              @for (displayedTab of displayedTabsSignal(); track $index) {
+                <div
+                  class="tab-pane fade show"
+                  [class.active]="activeTab === displayedTab.value"
+                  [id]="displayedTab.value"
+                  role="tabpanel"
+                  [attr.aria-labelledby]="displayedTab.value + '-tab'">
+                  @if (displayedTab.value === 'dependency') {
+                    <app-product-detail-maven-content
+                      [productDetail]="productDetail()"
+                      [selectedVersion]="selectedVersion">
+                    </app-product-detail-maven-content>
+                  } @else {
+                    <markdown
+                      [lang]="languageService.selectedLanguage()"
+                      class="readme-content"
+                      [data]="
+                        getProductModuleContentValue(displayedTab)
+                          | multilingualism: languageService.selectedLanguage()
+                      "></markdown>
+                  }
+                </div>
+              }
             }
-          }
-        </div>
-      } 
+          </div>
+        } 
       </div>
 
       <div

--- a/marketplace-ui/src/app/modules/product/product-detail/product-detail.component.html
+++ b/marketplace-ui/src/app/modules/product/product-detail/product-detail.component.html
@@ -16,7 +16,7 @@
         </a>
       </div>
       <div class="version-gap d-flex flex-column flex-lg-row justify-content-between">
-        <div class="d-flex flex-column module-gap">
+        <div class="d-flex flex-column module-gap connector-title-container">
           <div class="d-flex">
             <div class="logo__image-container">
               <img
@@ -32,8 +32,7 @@
             </div>
             <h1
               [lang]="languageService.selectedLanguage()"
-              class="product-title align-items-start default-cursor">
-              {{
+              class="product-title align-items-start default-cursor">{{
                 productDetail().names
                   | multilingualism: languageService.selectedLanguage()
               }}
@@ -79,7 +78,7 @@
           (selectedVersionChange)="
             loadDetailTabs($event)
           "></app-product-version-action>
-        </div>
+      </div>
     </div>
 
     <div class="detail-body d-flex flex-row align-items-start p-0 w-100">

--- a/marketplace-ui/src/app/modules/product/product-detail/product-detail.component.html
+++ b/marketplace-ui/src/app/modules/product/product-detail/product-detail.component.html
@@ -15,8 +15,8 @@
           </span>
         </a>
       </div>
-      <div class="version-gap d-flex flex-column flex-lg-row justify-content-between">
-        <div class="d-flex flex-column module-gap connector-title-container">
+      <div class="version-gap d-flex flex-column flex-xl-row justify-content-between">
+        <div class="connector-title-container d-flex flex-column module-gap">
           <div class="d-flex">
             <div class="logo__image-container">
               <img
@@ -84,6 +84,7 @@
     <div class="detail-body d-flex flex-row align-items-start p-0 w-100">
       <div
         class="tab-group d-flex flex-column justify-content-center align-items-start p-0 col-12 col-xl-8">
+        @if (displayedTabsSignal().length > 0) {
         <div class="row-tab d-none d-xl-block col-12">
           <ul ngbNav class="nav nav-tabs form-tabs">
             @for (displayedTab of displayedTabsSignal(); track $index) {
@@ -176,6 +177,7 @@
             }
           }
         </div>
+      } 
       </div>
 
       <div

--- a/marketplace-ui/src/app/modules/product/product-detail/product-detail.component.scss
+++ b/marketplace-ui/src/app/modules/product/product-detail/product-detail.component.scss
@@ -17,6 +17,22 @@
   height: 43px;
 }
 
+.connector-title-container {
+  width: 75%;
+  
+  @media (max-width: 1399px) {
+    width: 70%;
+  }
+  
+  @media (max-width: 1199px) {
+    width: 65%;
+  }
+
+  @media (max-width: 991px) {
+    width: 100%;
+  }
+}
+
 .back-link {
   font-weight: 500;
   line-height: 120%;
@@ -177,7 +193,10 @@
   display: none;
 }
 
-.flexible-gap,
+.flexible-gap {
+  gap: 4.5rem;
+}
+
 .module-gap {
   gap: 4.5rem;
 }

--- a/marketplace-ui/src/app/modules/product/product-detail/product-detail.component.scss
+++ b/marketplace-ui/src/app/modules/product/product-detail/product-detail.component.scss
@@ -18,17 +18,13 @@
 }
 
 .connector-title-container {
-  width: 75%;
-  
+  width: 70%;
+
   @media (max-width: 1399px) {
-    width: 70%;
-  }
-  
-  @media (max-width: 1199px) {
-    width: 65%;
+    width: 60%;
   }
 
-  @media (max-width: 991px) {
+  @media (max-width: 1199px) {
     width: 100%;
   }
 }

--- a/marketplace-ui/src/app/modules/product/product-detail/product-detail.component.spec.ts
+++ b/marketplace-ui/src/app/modules/product/product-detail/product-detail.component.spec.ts
@@ -749,4 +749,29 @@ describe('ProductDetailComponent', () => {
       ProductDetailActionType.STANDARD
     );
   });
+
+  it('displayed tabs array should have size 0 if product module content description, setup, demo, dependcy are all empty', () => {
+    const mockContent: ProductModuleContent = {
+      ...MOCK_PRODUCT_MODULE_CONTENT,
+    };
+    component.productModuleContent.set(mockContent);
+
+    expect(component.displayedTabsSignal().length).toBe(0);
+  });
+
+  it('should hide tab and tab content when all tabs have no content', () => {
+    const mockContent: ProductModuleContent = {
+      ...MOCK_PRODUCT_MODULE_CONTENT,
+    };
+    component.productModuleContent.set(mockContent);
+
+    const tabGroup = fixture.debugElement.query(By.css('.tab-group'));
+    const tabs = tabGroup.query(By.css('.row-tab d-none d-xl-block col-12'));
+    const dropdown = tabGroup.query(By.css('.dropdown-tab d-block d-xl-none d-flex flex-row justify-content-center align-items-center w-100'));
+    const tabContent = tabGroup.query(By.css('.tab-content col-12 default-cursor'));
+
+    expect(tabs).toBeFalsy();
+    expect(dropdown).toBeFalsy();
+    expect(tabContent).toBeFalsy();
+  });
 });

--- a/marketplace-ui/src/app/shared/components/common-dropdown/common-dropdown.component.html
+++ b/marketplace-ui/src/app/shared/components/common-dropdown/common-dropdown.component.html
@@ -6,7 +6,7 @@
           [attr.aria-label]="ariaLabel">
     {{ selectedItem }}
   </button>
-  <div class="dropdown-menu menu-bar" [class.show]="isDropdownOpen">
+  <div class="dropdown-menu menu-bar w-100" [class.show]="isDropdownOpen">
     @for (item of items; track $index) {
       <div class="dropdown-item item-bar text-primary" (click)="onSelect(item)"
           [attr.metaDataJsonUrl]="item.metaDataJsonUrl"

--- a/marketplace-ui/src/app/shared/components/common-dropdown/common-dropdown.component.ts
+++ b/marketplace-ui/src/app/shared/components/common-dropdown/common-dropdown.component.ts
@@ -14,7 +14,7 @@ import { ActiveDropDownItemPipe } from '../../pipes/active-dropdown-item.pipe';
   templateUrl: './common-dropdown.component.html',
   styleUrl: './common-dropdown.component.scss'
 })
-export class CommonDropdownComponent<T extends string> implements OnInit{
+export class CommonDropdownComponent<T extends string> {
   translateService = inject(TranslateService);
 
   @Input() items: ItemDropdown<T>[] = [];
@@ -27,12 +27,6 @@ export class CommonDropdownComponent<T extends string> implements OnInit{
   isDropdownOpen = false;
   @Input() metaDataJsonUrl: string | undefined = '';
   
-  ngOnInit(): void {
-    console.log(this.items);
-    console.log(this.selectedItem);
-    
-  }
-
   toggleDropdown() {
     this.isDropdownOpen = !this.isDropdownOpen;
   }

--- a/marketplace-ui/src/app/shared/components/common-dropdown/common-dropdown.component.ts
+++ b/marketplace-ui/src/app/shared/components/common-dropdown/common-dropdown.component.ts
@@ -26,7 +26,7 @@ export class CommonDropdownComponent<T extends string> {
   elementRef = inject(ElementRef);
   isDropdownOpen = false;
   @Input() metaDataJsonUrl: string | undefined = '';
-  
+
   toggleDropdown() {
     this.isDropdownOpen = !this.isDropdownOpen;
   }

--- a/marketplace-ui/src/app/shared/components/common-dropdown/common-dropdown.component.ts
+++ b/marketplace-ui/src/app/shared/components/common-dropdown/common-dropdown.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, HostListener, inject, Input, OnInit, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, HostListener, inject, Input, Output } from '@angular/core';
 import { NgClass } from '@angular/common';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ItemDropdown } from '../../models/item-dropdown.model';

--- a/marketplace-ui/src/app/shared/components/common-dropdown/common-dropdown.component.ts
+++ b/marketplace-ui/src/app/shared/components/common-dropdown/common-dropdown.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, HostListener, inject, Input, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, HostListener, inject, Input, OnInit, Output } from '@angular/core';
 import { NgClass } from '@angular/common';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ItemDropdown } from '../../models/item-dropdown.model';
@@ -14,7 +14,7 @@ import { ActiveDropDownItemPipe } from '../../pipes/active-dropdown-item.pipe';
   templateUrl: './common-dropdown.component.html',
   styleUrl: './common-dropdown.component.scss'
 })
-export class CommonDropdownComponent<T extends string> {
+export class CommonDropdownComponent<T extends string> implements OnInit{
   translateService = inject(TranslateService);
 
   @Input() items: ItemDropdown<T>[] = [];
@@ -26,6 +26,12 @@ export class CommonDropdownComponent<T extends string> {
   elementRef = inject(ElementRef);
   isDropdownOpen = false;
   @Input() metaDataJsonUrl: string | undefined = '';
+  
+  ngOnInit(): void {
+    console.log(this.items);
+    console.log(this.selectedItem);
+    
+  }
 
   toggleDropdown() {
     this.isDropdownOpen = !this.isDropdownOpen;


### PR DESCRIPTION
-On medium screen, prevent the "Install Now" and "Download" button from falling off each other. 
-Width of dropdown menu of download button is now the same with download button's width. 
-Gap between the download button and its dropdown menu is now smaller, same with figma. 
-With a connector with less than 4 version to download, the download dropdown no longer has a blank space, instead its height now fits the content.