### PR TITLE
MARP-2489: Portal-doc does not sync correctly after migrating to Postgres

### DIFF
--- a/marketplace-build/config/nginx/dev/nginx.conf
+++ b/marketplace-build/config/nginx/dev/nginx.conf
@@ -31,6 +31,10 @@ http {
 
         # Start: Handle for DOCs
         location /market-cache/ {
+            add_header Cache-Control "no-store, no-cache, must-revalidate";
+            add_header Pragma "no-cache";
+            add_header Expires 0;
+
             alias /usr/share/nginx/html/market-cache/;
             index index.html;
             try_files $uri $uri/ /index.html;

--- a/marketplace-build/config/nginx/release/nginx.conf
+++ b/marketplace-build/config/nginx/release/nginx.conf
@@ -35,6 +35,10 @@ http {
 
         # Start: Handle for DOCs
         location /market-cache/ {
+            add_header Cache-Control "no-store, no-cache, must-revalidate";
+            add_header Pragma "no-cache";
+            add_header Expires 0;
+
             alias /usr/share/nginx/html/market-cache/;
             index index.html;
             try_files $uri $uri/ /index.html;

--- a/marketplace-service/src/main/java/com/axonivy/market/MarketplaceServiceApplication.java
+++ b/marketplace-service/src/main/java/com/axonivy/market/MarketplaceServiceApplication.java
@@ -64,7 +64,7 @@ public class MarketplaceServiceApplication {
     if (ObjectUtils.isEmpty(productIds)) {
       log.warn("Synchronizing External Document: Nothing updated");
     }
-    productIds.forEach(id -> externalDocumentService.syncDocumentForProduct(id, false));
+    productIds.forEach(id -> externalDocumentService.syncDocumentForProduct(id, false, null));
     watch.stop();
     log.warn("Synchronizing External Document: Finished synchronizing data for Document in [{}] milliseconds",
         watch.getTime());

--- a/marketplace-service/src/main/java/com/axonivy/market/constants/DirectoryConstants.java
+++ b/marketplace-service/src/main/java/com/axonivy/market/constants/DirectoryConstants.java
@@ -8,5 +8,4 @@ public class DirectoryConstants {
   public static final String DATA_DIR = "data";
   public static final String WORK_DIR = "work";
   public static final String CACHE_DIR = "market-cache";
-  public static final String MAVEN_DIR = "maven";
 }

--- a/marketplace-service/src/main/java/com/axonivy/market/repository/ExternalDocumentMetaRepository.java
+++ b/marketplace-service/src/main/java/com/axonivy/market/repository/ExternalDocumentMetaRepository.java
@@ -1,6 +1,7 @@
 package com.axonivy.market.repository;
 
 import com.axonivy.market.entity.ExternalDocumentMeta;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,12 +10,9 @@ import java.util.List;
 @Repository
 public interface ExternalDocumentMetaRepository extends JpaRepository<ExternalDocumentMeta, String> {
 
-  List<ExternalDocumentMeta> findByProductIdAndVersion(String productId, String version);
-
   List<ExternalDocumentMeta> findByProductId(String productId);
 
-  void deleteByProductIdAndVersion(String productId, String version);
-
+  @Transactional
   void deleteByProductIdAndVersionIn(String productId, List<String> versions);
 
   List<ExternalDocumentMeta> findByProductIdAndVersionIn(String productId, List<String> versions);

--- a/marketplace-service/src/main/java/com/axonivy/market/schedulingtask/ScheduledTasks.java
+++ b/marketplace-service/src/main/java/com/axonivy/market/schedulingtask/ScheduledTasks.java
@@ -38,7 +38,7 @@ public class ScheduledTasks {
   public void syncDataForProductDocuments() {
     log.warn("Started sync data for product document");
     for (var product : productRepo.findAllProductsHaveDocument()) {
-      externalDocumentService.syncDocumentForProduct(product.getId(), false);
+      externalDocumentService.syncDocumentForProduct(product.getId(), false, null);
     }
   }
 

--- a/marketplace-service/src/main/java/com/axonivy/market/service/ExternalDocumentService.java
+++ b/marketplace-service/src/main/java/com/axonivy/market/service/ExternalDocumentService.java
@@ -6,7 +6,7 @@ import com.axonivy.market.entity.Product;
 import java.util.List;
 
 public interface ExternalDocumentService {
-  void syncDocumentForProduct(String productId, boolean isResetSync);
+  void syncDocumentForProduct(String productId, boolean isResetSync, String version);
 
   List<Product> findAllProductsHaveDocument();
 

--- a/marketplace-service/src/main/java/com/axonivy/market/service/impl/ExternalDocumentServiceImpl.java
+++ b/marketplace-service/src/main/java/com/axonivy/market/service/impl/ExternalDocumentServiceImpl.java
@@ -3,6 +3,7 @@ package com.axonivy.market.service.impl;
 import com.axonivy.market.bo.DownloadOption;
 import com.axonivy.market.constants.CommonConstants;
 import com.axonivy.market.constants.DirectoryConstants;
+import com.axonivy.market.constants.MavenConstants;
 import com.axonivy.market.entity.Artifact;
 import com.axonivy.market.entity.ExternalDocumentMeta;
 import com.axonivy.market.entity.Product;
@@ -14,24 +15,19 @@ import com.axonivy.market.service.ExternalDocumentService;
 import com.axonivy.market.service.FileDownloadService;
 import com.axonivy.market.util.MavenUtils;
 import com.axonivy.market.util.VersionUtils;
-import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.RegExUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 @Log4j2
@@ -47,28 +43,33 @@ public class ExternalDocumentServiceImpl implements ExternalDocumentService {
   final ArtifactRepository artifactRepo;
 
   @Override
-  @Transactional
-  public void syncDocumentForProduct(String productId, boolean isResetSync) {
-    Optional.ofNullable(productRepo.findProductByIdAndRelatedData(productId)).ifPresent(product -> {
-      List<Artifact> docArtifacts = fetchDocArtifacts(product.getArtifacts());
+  public void syncDocumentForProduct(String productId, boolean isResetSync, String version) {
+    Product product = productRepo.findProductByIdAndRelatedData(productId);
+    if (product == null) {
+      log.warn("Cannot find the product for sync document {}", productId);
+      return;
+    }
+    List<Artifact> docArtifacts = fetchDocArtifacts(product.getArtifacts());
+    List<String> releasedVersions = getValidReleaseVersionsFromProduct(product.getReleasedVersions(), version);
+    if (isNotEmpty(docArtifacts) && isNotEmpty(releasedVersions)) {
+      downloadExternalDocumentFromMavenAndUpdateMetaData(productId, isResetSync, releasedVersions, docArtifacts);
+    }
+  }
 
-      List<String> releasedVersions = product.getReleasedVersions().stream()
-          .filter(VersionUtils::isValidFormatReleasedVersion)
-          .distinct()
-          .toList();
+  private static List<String> getValidReleaseVersionsFromProduct(List<String> releaseVersions, String version) {
+    return isNotEmpty(version) ? List.of(version) : Optional.ofNullable(releaseVersions).stream()
+        .flatMap(List::stream).filter(VersionUtils::isValidFormatReleasedVersion).distinct().toList();
+  }
 
-      if (ObjectUtils.isEmpty(docArtifacts) || ObjectUtils.isEmpty(releasedVersions)) return;
+  private void downloadExternalDocumentFromMavenAndUpdateMetaData(String productId, boolean isResetSync,
+      List<String> releasedVersions, List<Artifact> docArtifacts) {
+    if (isResetSync) {
+      externalDocumentMetaRepo.deleteByProductIdAndVersionIn(productId, releasedVersions);
+    }
 
-      if (isResetSync) externalDocumentMetaRepo.deleteByProductIdAndVersionIn(productId, releasedVersions);
-
-      Set<ExternalDocumentMeta> externalDocumentMetas = new HashSet<>();
-      for (Artifact artifact : docArtifacts) {
-        List<ExternalDocumentMeta> newDocs = createDocumentationForProduct(productId, isResetSync, artifact,
-            releasedVersions);
-        externalDocumentMetas.addAll(newDocs);
-      }
-      externalDocumentMetaRepo.saveAll(externalDocumentMetas);
-    });
+    for (Artifact artifact : docArtifacts) {
+      createDocumentationForProduct(productId, isResetSync, artifact, releasedVersions);
+    }
   }
 
   @Override
@@ -89,51 +90,62 @@ public class ExternalDocumentServiceImpl implements ExternalDocumentService {
         .findAny().orElse(null);
   }
 
-  private List<ExternalDocumentMeta> createDocumentationForProduct(String productId, boolean isResetSync,
+  private void createDocumentationForProduct(String productId, boolean isResetSync,
       Artifact artifact, List<String> releasedVersions) {
-    List<ExternalDocumentMeta> docMetas = externalDocumentMetaRepo.findByProductIdAndVersionIn(productId,
-        releasedVersions);
-
-    if (docMetas.isEmpty()) {
-      return releasedVersions.stream()
-          .map(version -> createDocumentMeta(productId, artifact, version, isResetSync))
-          .filter(Objects::nonNull)
-          .toList();
+    List<String> missingVersions = getMissingVersions(productId, isResetSync, releasedVersions);
+    for (String version : missingVersions) {
+      var externalDocumentMeta = createDocumentMeta(productId, artifact, version, isResetSync);
+      if (externalDocumentMeta != null) {
+        externalDocumentMetaRepo.save(externalDocumentMeta);
+      }
     }
-
-    return docMetas.stream()
-        .map(ExternalDocumentMeta::getVersion)
-        .filter(version -> !releasedVersions.contains(version))
-        .map(version -> createDocumentMeta(productId, artifact, version, isResetSync))
-        .filter(Objects::nonNull)
-        .toList();
   }
 
+  private List<String> getMissingVersions(String productId, boolean isResetSync, List<String> releasedVersions) {
+    List<String> missingVersions = new ArrayList<>(releasedVersions);
+    if (!isResetSync) {
+      List<String> existedDocMetaVersions = externalDocumentMetaRepo.findByProductIdAndVersionIn(productId,
+          releasedVersions).stream().map(ExternalDocumentMeta::getVersion).toList();
+      missingVersions = releasedVersions.stream().filter(version -> !existedDocMetaVersions.contains(version)).toList();
+    }
+    return missingVersions;
+  }
 
   private ExternalDocumentMeta createDocumentMeta(String productId, Artifact artifact, String version,
       boolean isResetSync) {
+    // Switch to nexus repo for artifact
+    artifact.setRepoUrl(MavenConstants.DEFAULT_IVY_MIRROR_MAVEN_BASE_URL);
     String downloadDocUrl = MavenUtils.buildDownloadUrl(artifact, version);
     String location = downloadDocAndUnzipToShareFolder(downloadDocUrl, isResetSync);
-    if (StringUtils.isBlank(location)) return null;
+    if (StringUtils.isBlank(location)) {
+      return null;
+    }
 
+    // remove prefix 'data' and replace all ms win separator to slash if present
     String locationRelative = location.substring(location.indexOf(DirectoryConstants.CACHE_DIR));
     locationRelative = RegExUtils.replaceAll(String.format(DOC_URL_PATTERN, locationRelative), MS_WIN_SEPARATOR,
         CommonConstants.SLASH);
+    ExternalDocumentMeta externalDocumentMeta = new ExternalDocumentMeta();
+    List<ExternalDocumentMeta> existingExternalDocumentMeta = externalDocumentMetaRepo.findByProductIdAndVersionIn(
+        productId, List.of(version));
+    if (!existingExternalDocumentMeta.isEmpty()) {
+      externalDocumentMeta = existingExternalDocumentMeta.get(0);
+    }
+    externalDocumentMeta.setProductId(productId);
+    externalDocumentMeta.setVersion(version);
+    externalDocumentMeta.setArtifactId(artifact.getArtifactId());
+    externalDocumentMeta.setArtifactName(artifact.getName());
+    externalDocumentMeta.setRelativeLink(locationRelative);
+    externalDocumentMeta.setStorageDirectory(location);
 
-    return ExternalDocumentMeta.builder()
-        .productId(productId)
-        .artifactId(artifact.getArtifactId())
-        .artifactName(artifact.getName())
-        .version(version)
-        .storageDirectory(location)
-        .relativeLink(locationRelative)
-        .build();
+    return externalDocumentMeta;
   }
 
   private List<Artifact> fetchDocArtifacts(List<Artifact> artifacts) {
-    List<String> artifactIds = artifacts.stream().map(Artifact::getId).collect(Collectors.toCollection(ArrayList::new));
-    List<Artifact> allArtifacts = artifactRepo.findAllByIdInAndFetchArchivedArtifacts(artifactIds);
-    return allArtifacts.stream().filter(artifact -> BooleanUtils.isTrue(artifact.getDoc())).toList();
+    List<String> artifactIds = artifacts.stream().map(Artifact::getId).distinct().toList();
+    return artifactRepo.findAllByIdInAndFetchArchivedArtifacts(artifactIds).stream()
+        .filter(artifact -> BooleanUtils.isTrue(artifact.getDoc()))
+        .toList();
   }
 
   private String downloadDocAndUnzipToShareFolder(String downloadDocUrl, boolean isResetSync) {

--- a/marketplace-service/src/main/java/com/axonivy/market/service/impl/FileDownloadServiceImpl.java
+++ b/marketplace-service/src/main/java/com/axonivy/market/service/impl/FileDownloadServiceImpl.java
@@ -22,15 +22,7 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.EnumSet;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -44,9 +36,8 @@ public class FileDownloadServiceImpl implements FileDownloadService {
   private static final String DOC_DIR = "doc";
   private static final String ZIP_EXTENSION = ".zip";
   private static final Set<PosixFilePermission> PERMS = EnumSet.allOf(PosixFilePermission.class);
-  private static final int THRESHOLD_ENTRIES = 10000;
   private static final int THRESHOLD_SIZE = 1000000000;
-  private static final double THRESHOLD_RATIO = 10;
+  public static final String IAR = "iar";
 
   @Override
   public byte[] downloadFile(String url) {
@@ -64,17 +55,12 @@ public class FileDownloadServiceImpl implements FileDownloadService {
 
   @Override
   public String downloadAndUnzipFile(String url, DownloadOption downloadOption) throws IOException {
-    if (StringUtils.isBlank(url) || !StringUtils.endsWithAny(url, ZIP_EXTENSION, "iar")) {
+    if (StringUtils.isBlank(url) || !StringUtils.endsWithAny(url, ZIP_EXTENSION, IAR)) {
       log.warn("Request URL not a ZIP file - {}", url);
       return EMPTY;
     }
 
-    String location;
-    if (downloadOption != null && StringUtils.isNotBlank(downloadOption.getWorkingDirectory())) {
-      location = downloadOption.getWorkingDirectory();
-    } else {
-      location = generateCacheStorageDirectory(url);
-    }
+    String location = determineLocation(url, downloadOption);
     Path tempZipPath = createTempFileFromUrlAndExtractToLocation(url, location, downloadOption);
     if (tempZipPath != null) {
       if (downloadOption != null && downloadOption.isShouldGrantPermission()) {
@@ -85,15 +71,20 @@ public class FileDownloadServiceImpl implements FileDownloadService {
     return location;
   }
 
+  private String determineLocation(String url, DownloadOption downloadOption) {
+    String location;
+    if (downloadOption != null && StringUtils.isNotBlank(downloadOption.getWorkingDirectory())) {
+      location = downloadOption.getWorkingDirectory();
+    } else {
+      location = generateCacheStorageDirectory(url);
+    }
+    return location;
+  }
+
   private Path createTempFileFromUrlAndExtractToLocation(String url, String location,
       DownloadOption downloadOption) throws IOException {
-    File cacheFolder = FileUtils.createNewFile(location);
-    if (cacheFolder.exists() && cacheFolder.isDirectory() && ObjectUtils.isNotEmpty(
-        cacheFolder.listFiles()) && downloadOption != null && !downloadOption.isForced()) {
-      log.warn("Data is already in {}", location);
+    if (prepareDirectoryForUnzipProcess(location, downloadOption)) {
       return null;
-    } else {
-      createFolder(location);
     }
 
     Path tempZipPath = createTempFile();
@@ -105,6 +96,24 @@ public class FileDownloadServiceImpl implements FileDownloadService {
     Files.write(tempZipPath, fileContent);
     unzipFile(tempZipPath.toString(), location);
     return tempZipPath;
+  }
+
+  private boolean prepareDirectoryForUnzipProcess(String location, DownloadOption downloadOption) {
+    boolean isDataExistedInFolder = false;
+    File cacheFolder = FileUtils.createNewFile(location);
+    boolean isForced = Optional.ofNullable(downloadOption).map(DownloadOption::isForced).orElse(false);
+    if (cacheFolder.exists() && cacheFolder.isDirectory()) {
+      if (isForced) {
+        log.warn("Forced delete {} for re-create again due to DownloadOption::isForced is true", location);
+        deleteDirectory(cacheFolder.toPath());
+      } else if (ObjectUtils.isNotEmpty(cacheFolder.listFiles())) {
+        isDataExistedInFolder = true;
+      }
+    }
+    if (!isDataExistedInFolder) {
+      createFolder(location);
+    }
+    return isDataExistedInFolder;
   }
 
   private Path createTempFile() throws IOException {
@@ -125,7 +134,6 @@ public class FileDownloadServiceImpl implements FileDownloadService {
     Path destDirPath = Paths.get(location).toAbsolutePath().normalize();
     try (ZipFile zipFile = new ZipFile(new File(zipFilePath))) {
       Enumeration<? extends ZipEntry> entries = zipFile.entries();
-      int totalEntryArchive = 0;
 
       while (entries.hasMoreElements()) {
         ZipEntry zipEntry = entries.nextElement();
@@ -136,11 +144,10 @@ public class FileDownloadServiceImpl implements FileDownloadService {
         if (zipEntry.isDirectory()) {
           createFolder(entryPath.toString());
         } else {
-          totalEntryArchive++;
           totalSizeArchive = extractFile(zipFile, zipEntry, entryPath.toString(), totalSizeArchive);
         }
-        if (totalSizeArchive > THRESHOLD_SIZE || totalEntryArchive > THRESHOLD_ENTRIES) {
-          log.warn("Unzip is skipped due to threshold issue {} {}", totalSizeArchive, totalEntryArchive);
+        if (totalSizeArchive > THRESHOLD_SIZE) {
+          log.warn("Unzip is skipped due to threshold issue {}", totalSizeArchive);
           break;
         }
       }
@@ -152,18 +159,10 @@ public class FileDownloadServiceImpl implements FileDownloadService {
     try (BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(filePath))) {
       InputStream stream = new BufferedInputStream(zipFile.getInputStream(zipEntry));
       byte[] bytesIn = new byte[4096];
-      int totalSizeEntry = 0;
       int read;
       while ((read = stream.read(bytesIn)) != -1) {
         bos.write(bytesIn, 0, read);
-        totalSizeEntry += read;
         totalSizeArchive += read;
-
-        var compressionRatio = totalSizeEntry / zipEntry.getCompressedSize();
-        if (compressionRatio > THRESHOLD_RATIO) {
-          log.warn("Extract file is skipped due to threshold issue {}", compressionRatio);
-          break;
-        }
       }
       stream.close();
     } catch (IOException e) {

--- a/marketplace-service/src/main/java/com/axonivy/market/service/impl/ProductContentServiceImpl.java
+++ b/marketplace-service/src/main/java/com/axonivy/market/service/impl/ProductContentServiceImpl.java
@@ -181,7 +181,7 @@ public class ProductContentServiceImpl implements ProductContentService {
 
   private void zipArtifact(String version, String downloadUrl, ZipOutputStream zipOut) throws IOException {
     if (StringUtils.isNoneBlank(downloadUrl)) {
-      byte[] artifactData = fileDownloadService.downloadFile(downloadUrl);
+      byte[] artifactData = fileDownloadService.safeDownload(downloadUrl);
       if (ObjectUtils.isEmpty(artifactData)) {
         return;
       }

--- a/marketplace-service/src/main/java/com/axonivy/market/service/impl/ProductDependencyServiceImpl.java
+++ b/marketplace-service/src/main/java/com/axonivy/market/service/impl/ProductDependencyServiceImpl.java
@@ -235,7 +235,7 @@ public class ProductDependencyServiceImpl implements ProductDependencyService {
 
   private byte[] downloadPOMFileFromMaven(String downloadUrl) throws HttpClientErrorException {
     ObjectUtils.requireNonEmpty(downloadUrl, "Download URL must not be null");
-    var changeToMirrorRepo = downloadUrl.replaceFirst(DEFAULT_IVY_MAVEN_BASE_URL, DEFAULT_IVY_MIRROR_MAVEN_BASE_URL);
+    var changeToMirrorRepo = downloadUrl.replace(DEFAULT_IVY_MAVEN_BASE_URL, DEFAULT_IVY_MIRROR_MAVEN_BASE_URL);
     var pomURL = changeToMirrorRepo.replace(DOT_SEPARATOR.concat(DEFAULT_PRODUCT_TYPE), DOT_SEPARATOR.concat(POM));
     return fileDownloadService.downloadFile(pomURL);
   }

--- a/marketplace-service/src/main/java/com/axonivy/market/service/impl/ProductServiceImpl.java
+++ b/marketplace-service/src/main/java/com/axonivy/market/service/impl/ProductServiceImpl.java
@@ -458,7 +458,7 @@ public class ProductServiceImpl implements ProductService {
       getMetadataContent(mavenArtifact, product, nonSyncReleasedVersions);
     }
     metadataService.updateArtifactAndMetadata(product.getId(), nonSyncReleasedVersions, product.getArtifacts());
-    externalDocumentService.syncDocumentForProduct(product.getId(), false);
+    externalDocumentService.syncDocumentForProduct(product.getId(), false, null);
   }
 
   private void getMetadataContent(Artifact artifact, Product product, List<String> nonSyncReleasedVersions) {

--- a/marketplace-service/src/test/java/com/axonivy/market/controller/ExternalDocumentControllerTest.java
+++ b/marketplace-service/src/test/java/com/axonivy/market/controller/ExternalDocumentControllerTest.java
@@ -46,12 +46,12 @@ class ExternalDocumentControllerTest {
 
   @Test
   void testSyncDocumentForProduct() {
-    var result = externalDocumentController.syncDocumentForProduct(TOKEN, true);
+    var result = externalDocumentController.syncDocumentForProduct(TOKEN, true, null, null);
     assertEquals(HttpStatus.NO_CONTENT, result.getStatusCode(), "Should be no product found");
 
     var mockProduct = mock(Product.class);
     when(service.findAllProductsHaveDocument()).thenReturn(List.of(mockProduct));
-    result = externalDocumentController.syncDocumentForProduct(TOKEN, true);
+    result = externalDocumentController.syncDocumentForProduct(TOKEN, true, null, null);
     assertEquals(HttpStatus.OK, result.getStatusCode(), "Should return at least one product");
   }
 

--- a/marketplace-service/src/test/java/com/axonivy/market/service/SystemTasksTest.java
+++ b/marketplace-service/src/test/java/com/axonivy/market/service/SystemTasksTest.java
@@ -45,7 +45,7 @@ class SystemTasksTest {
     when(productRepo.findAllProductsHaveDocument()).thenReturn(List.of(mockProduct));
     tasks.syncDataForProductDocuments();
     verify(productRepo, times(1)).findAllProductsHaveDocument();
-    verify(externalDocumentService, times(1)).syncDocumentForProduct(PORTAL, false);
+    verify(externalDocumentService, times(1)).syncDocumentForProduct(PORTAL, false, null);
   }
 
   @Test

--- a/marketplace-service/src/test/java/com/axonivy/market/service/impl/ExternalDocumentServiceImplTest.java
+++ b/marketplace-service/src/test/java/com/axonivy/market/service/impl/ExternalDocumentServiceImplTest.java
@@ -46,23 +46,37 @@ class ExternalDocumentServiceImplTest extends BaseSetup {
   @Test
   void testSyncDocumentForProduct() throws IOException {
     when(productRepository.findProductByIdAndRelatedData(PORTAL)).thenReturn(mockPortalProductHasNoArtifact().get());
-    service.syncDocumentForProduct(PORTAL,  true);
+    service.syncDocumentForProduct(PORTAL,  true, null);
     verify(productRepository, times(1)).findProductByIdAndRelatedData(any());
-    verify(externalDocumentMetaRepository, times(0)).findByProductIdAndVersion(any(), any());
 
     when(artifactRepository.findAllByIdInAndFetchArchivedArtifacts(any())).thenReturn(mockPortalProduct().get().getArtifacts());
     when(productRepository.findProductByIdAndRelatedData(PORTAL)).thenReturn(mockPortalProduct().get());
-    service.syncDocumentForProduct(PORTAL,  false);
+    service.syncDocumentForProduct(PORTAL,  false, null);
     verify(externalDocumentMetaRepository, times(1)).findByProductIdAndVersionIn(any(), any());
 
     when(fileDownloadService.downloadAndUnzipFile(any(), any())).thenReturn("data" + RELATIVE_LOCATION);
-    service.syncDocumentForProduct(PORTAL,  true);
-    verify(externalDocumentMetaRepository, times(2)).saveAll(any());
+    service.syncDocumentForProduct(PORTAL,  true, null);
+    verify(externalDocumentMetaRepository, times(2)).save(any());
 
     when(artifactRepository.findAllByIdInAndFetchArchivedArtifacts(any())).thenReturn(mockPortalProduct().get().getArtifacts());
     when(productRepository.findProductByIdAndRelatedData(PORTAL)).thenReturn(mockPortalProduct().get());
     when(externalDocumentMetaRepository.findByProductIdAndVersionIn(any(),any())).thenReturn(List.of(createExternalDocumentMock()));
-    service.syncDocumentForProduct(PORTAL,  false);
+    service.syncDocumentForProduct(PORTAL,  false, null);
+    verify(externalDocumentMetaRepository, times(6)).findByProductIdAndVersionIn(any(), any());
+  }
+
+  @Test
+  void testSyncDocumentForProductIdAndVersion() throws IOException {
+    when(artifactRepository.findAllByIdInAndFetchArchivedArtifacts(any()))
+        .thenReturn(mockPortalProduct().map(Product::getArtifacts).orElse(null));
+    when(productRepository.findProductByIdAndRelatedData(PORTAL)).thenReturn(mockPortalProduct().orElse(null));
+    when(externalDocumentMetaRepository.findByProductIdAndVersionIn(any(),any()))
+        .thenReturn(List.of(createExternalDocumentMock()));
+    when(fileDownloadService.downloadAndUnzipFile(any(), any())).thenReturn("data" + RELATIVE_LOCATION);
+
+    service.syncDocumentForProduct(PORTAL,  true, MOCK_RELEASED_VERSION);
+    verify(productRepository, times(1)).findProductByIdAndRelatedData(any());
+    verify(externalDocumentMetaRepository, times(1)).save(any());
   }
 
   @Test

--- a/marketplace-service/src/test/java/com/axonivy/market/service/impl/FileDownloadServiceImplTest.java
+++ b/marketplace-service/src/test/java/com/axonivy/market/service/impl/FileDownloadServiceImplTest.java
@@ -11,6 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
 
 import java.io.File;
 import java.io.IOException;
@@ -71,7 +72,8 @@ class FileDownloadServiceImplTest {
   @Test
   void testDownloadAndUnzipFileWithNullTempZipPath() throws IOException {
     try (MockedStatic<Files> mockedFiles = Mockito.mockStatic(Files.class);
-         MockedStatic<FileUtils> mockFileUtils = Mockito.mockStatic(FileUtils.class)) {
+         MockedStatic<FileUtils> mockFileUtils = Mockito.mockStatic(FileUtils.class);
+         MockedStatic<RestTemplate> mockedRestTemplate = Mockito.mockStatic(RestTemplate.class)) {
 
       File mockChildFile = Mockito.mock(File.class);
 

--- a/marketplace-service/src/test/java/com/axonivy/market/service/impl/ProductContentServiceImplTest.java
+++ b/marketplace-service/src/test/java/com/axonivy/market/service/impl/ProductContentServiceImplTest.java
@@ -96,7 +96,7 @@ class ProductContentServiceImplTest extends BaseSetup {
     ProductDependency productDependency = mockProductDependency();
     when(productDependencyRepository.findByProductIdAndArtifactIdAndVersion(MOCK_PRODUCT_ID, MOCK_DEMO_ARTIFACT_ID,
         MOCK_RELEASED_VERSION)).thenReturn(List.of(productDependency));
-    when(fileDownloadService.downloadFile(MOCK_DOWNLOAD_URL)).thenReturn(MOCK_DOWNLOAD_URL.getBytes());
+    when(fileDownloadService.safeDownload(MOCK_DOWNLOAD_URL)).thenReturn(MOCK_DOWNLOAD_URL.getBytes());
     when(productMarketplaceDataService.getVersionDownload(any(), any())).thenReturn(mockVersionDownload());
 
     VersionDownload versionDownload = productContentService.downloadZipArtifactFile(MOCK_PRODUCT_ID,


### PR DESCRIPTION
- Add expire cache for nginx
- Remove threadhold when unzip
- Add new option for sync doc
- Fix ưởng logic for detect new version