### PR TITLE
Revert "MARP-4110 fontsize and space between text and heading for documenation should be the same as in figma"

### DIFF
--- a/marketplace-ui/src/app/modules/product/product-detail/product-detail.component.scss
+++ b/marketplace-ui/src/app/modules/product/product-detail/product-detail.component.scss
@@ -370,13 +370,3 @@ hr {
   border-radius: 10px;
   opacity: 0px;
 }
-
-::ng-deep .tab-group .tab-content .tab-pane .readme-content {
-  h3, h4 {
-    margin-bottom: 1.5rem;
-  }
-
-  p, ul, ol {
-    margin-bottom: 5rem;
-  }
-}


### PR DESCRIPTION
Reverts axonivy-market/marketplace#632