### PR TITLE
MARP-4046 - fix remove soft link for matchedMajorVersions

### DIFF
--- a/marketplace-service/app/.dockerignore
+++ b/marketplace-service/app/.dockerignore
@@ -1,0 +1,35 @@
+target/
+data/
+unzip/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+/bin/

--- a/marketplace-service/app/src/main/java/com/axonivy/market/service/impl/ExternalDocumentServiceImpl.java
+++ b/marketplace-service/app/src/main/java/com/axonivy/market/service/impl/ExternalDocumentServiceImpl.java
@@ -318,15 +318,16 @@ public class ExternalDocumentServiceImpl implements ExternalDocumentService {
   }
 
   private String createSymlinkSafely(Path artifactRoot, Path targetPath, String majorVersion) {
-    var symlinkPath = artifactRoot.resolve(majorVersion);    
+    var symlinkPath = artifactRoot.resolve(majorVersion);
     try {
       if (Files.isSymbolicLink(symlinkPath)) {
-	    Path currentTargetPath = Files.readSymbolicLink(symlinkPath);
-	    if (!StringUtils.equals(targetPath.toString(), currentTargetPath.toString())) {
-	    	Files.delete(symlinkPath);
-	    	Files.createSymbolicLink(symlinkPath, Path.of(targetPath.toString()));	    	
-	    }	    
-      }         
+        Path currentTargetPath = Files.readSymbolicLink(symlinkPath);
+        if (StringUtils.equals(targetPath.toString(), currentTargetPath.toString())) {
+          return symlinkPath.toString();
+        }
+        Files.delete(symlinkPath);
+      }
+      Files.createSymbolicLink(symlinkPath, Path.of(targetPath.toString()));
       return symlinkPath.toString();
     } catch (IOException e) {
       log.error("Cannot create symlink for major version {}: {}", majorVersion, e.getMessage());

--- a/marketplace-service/app/src/main/java/com/axonivy/market/service/impl/ExternalDocumentServiceImpl.java
+++ b/marketplace-service/app/src/main/java/com/axonivy/market/service/impl/ExternalDocumentServiceImpl.java
@@ -317,26 +317,20 @@ public class ExternalDocumentServiceImpl implements ExternalDocumentService {
     return createSymlinkSafely(artifactRoot, fileName, majorVersion);
   }
 
-  private String createSymlinkSafely(Path artifactRoot, Path fileName, String majorVersion) {
-    var symlinkPath = artifactRoot.resolve(majorVersion);
-
+  private String createSymlinkSafely(Path artifactRoot, Path targetPath, String majorVersion) {
+    var symlinkPath = artifactRoot.resolve(majorVersion);    
     try {
-      unlinkSymlink(symlinkPath);      
-      Files.createSymbolicLink(symlinkPath, Path.of(fileName.toString()));
+      if (Files.isSymbolicLink(symlinkPath)) {
+	    Path currentTargetPath = Files.readSymbolicLink(symlinkPath);
+	    if (!StringUtils.equals(targetPath.toString(), currentTargetPath.toString())) {
+	    	Files.delete(symlinkPath);
+	    	Files.createSymbolicLink(symlinkPath, Path.of(targetPath.toString()));	    	
+	    }	    
+      }         
       return symlinkPath.toString();
     } catch (IOException e) {
       log.error("Cannot create symlink for major version {}: {}", majorVersion, e.getMessage());
       return null;
-    }
-  }
-  
-  private void unlinkSymlink(Path symlinkPath) {    
-    try {
-      if (Files.isSymbolicLink(symlinkPath)) {
-        Files.delete(symlinkPath);        
-      }
-    } catch (IOException e) {
-      log.error("Failed to unlink symlink at {}: {}", symlinkPath, e.getMessage());
     }
   }
 

--- a/marketplace-service/app/src/main/java/com/axonivy/market/service/impl/ExternalDocumentServiceImpl.java
+++ b/marketplace-service/app/src/main/java/com/axonivy/market/service/impl/ExternalDocumentServiceImpl.java
@@ -321,7 +321,7 @@ public class ExternalDocumentServiceImpl implements ExternalDocumentService {
     var symlinkPath = artifactRoot.resolve(majorVersion);
     try {
       if (Files.isSymbolicLink(symlinkPath)) {
-        Path currentTargetPath = Files.readSymbolicLink(symlinkPath);
+        var currentTargetPath = Files.readSymbolicLink(symlinkPath);
         if (StringUtils.equals(targetPath.toString(), currentTargetPath.toString())) {
           return symlinkPath.toString();
         }

--- a/marketplace-service/app/src/main/java/com/axonivy/market/service/impl/ExternalDocumentServiceImpl.java
+++ b/marketplace-service/app/src/main/java/com/axonivy/market/service/impl/ExternalDocumentServiceImpl.java
@@ -321,13 +321,22 @@ public class ExternalDocumentServiceImpl implements ExternalDocumentService {
     var symlinkPath = artifactRoot.resolve(majorVersion);
 
     try {
-      prepareDirectoryForSymlinkPath(symlinkPath);
-      var targetPath = Path.of(fileName.toString());
-      Files.createSymbolicLink(symlinkPath, targetPath);
+      unlinkSymlink(symlinkPath);      
+      Files.createSymbolicLink(symlinkPath, Path.of(fileName.toString()));
       return symlinkPath.toString();
     } catch (IOException e) {
       log.error("Cannot create symlink for major version {}: {}", majorVersion, e.getMessage());
       return null;
+    }
+  }
+  
+  private void unlinkSymlink(Path symlinkPath) {    
+    try {
+      if (Files.isSymbolicLink(symlinkPath)) {
+        Files.delete(symlinkPath);        
+      }
+    } catch (IOException e) {
+      log.error("Failed to unlink symlink at {}: {}", symlinkPath, e.getMessage());
     }
   }
 

--- a/marketplace-service/app/src/test/java/com/axonivy/market/service/impl/ExternalDocumentServiceImplTest.java
+++ b/marketplace-service/app/src/test/java/com/axonivy/market/service/impl/ExternalDocumentServiceImplTest.java
@@ -800,6 +800,30 @@ class ExternalDocumentServiceImplTest extends BaseSetup {
   }
 
   @Test
+  void testCreateSymlinkForParentExistingSymlinkWithDifferentTarget() throws IOException {    
+    Path productDir = CACHE_ROOT_PATH.resolve(PORTAL);
+    Path versionDir = productDir.resolve("12.5.0");
+    Path docDir = versionDir.resolve(DOC_DIR);
+    Files.createDirectories(docDir);
+
+    try (MockedStatic<Files> filesMock = mockStatic(Files.class)) {
+      Path symlinkPath = productDir.resolve(TEST_VERSION_12_5);
+      Path newTargetPath = Path.of("12.5.0");
+      Path oldTargetPath = Path.of("12.0.0");
+
+      filesMock.when(() -> Files.isSymbolicLink(symlinkPath)).thenReturn(true);
+      filesMock.when(() -> Files.readSymbolicLink(symlinkPath)).thenReturn(oldTargetPath);
+      filesMock.when(() -> Files.createSymbolicLink(eq(symlinkPath), eq(newTargetPath))).thenReturn(symlinkPath);
+
+      String result = service.createSymlinkForMajorVersion(docDir, TEST_VERSION_12_5);
+
+      assertEquals(symlinkPath.toString(), result, "Should return new symlink path after recreation");
+      filesMock.verify(() -> Files.delete(symlinkPath), times(1));
+      filesMock.verify(() -> Files.createSymbolicLink(eq(symlinkPath), eq(newTargetPath)), times(1));
+    }
+  }
+
+  @Test
   void testCreateSymlinkForParentIOException() throws IOException {
     Path cacheRoot = Paths.get(DirectoryConstants.DATA_CACHE_DIR).toAbsolutePath().normalize();
     Path productDir = cacheRoot.resolve(PORTAL);

--- a/marketplace-service/stable/.dockerignore
+++ b/marketplace-service/stable/.dockerignore
@@ -1,0 +1,35 @@
+target/
+data/
+unzip/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+/bin/


### PR DESCRIPTION
Update symbolic link for matchedMajorVersions in 3 cases:
- Symlink doesn't exist → creates it
- Symlink exists, same target → returns early, does nothing
- Symlink exists, different target → deletes it, then creates the new one