### PR TITLE
Feature/MARP-4641: add Monitoring page object and tests

### DIFF
--- a/marketplace-ui/.gitignore
+++ b/marketplace-ui/.gitignore
@@ -48,3 +48,8 @@ Thumbs.db
 /test-results
 
 **/assets/market-cache
+
+# Playwright
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/marketplace-ui/angular.json
+++ b/marketplace-ui/angular.json
@@ -20,10 +20,7 @@
             "outputPath": "dist",
             "index": "src/index.html",
             "browser": "src/main.ts",
-            "polyfills": [
-              "zone.js",
-              "@angular/localize/init"
-            ],
+            "polyfills": ["zone.js", "@angular/localize/init"],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": ["src/favicon.ico", "src/assets", "src/assets/_market", "src/robots.txt", "src/sitemap.xml"],
@@ -36,9 +33,7 @@
               "node_modules/@tabler/icons-webfont/dist/tabler-icons.css",
               "src/styles.scss"
             ],
-            "scripts": [
-              "node_modules/emoji-toolkit/lib/js/joypixels.min.js"
-            ],
+            "scripts": ["node_modules/emoji-toolkit/lib/js/joypixels.min.js"],
             "server": "src/main.server.ts",
             "prerender": false,
             "ssr": {
@@ -129,12 +124,24 @@
             "coverage": true,
             "watch": false
           }
+        },
+        "e2e": {
+          "builder": "playwright-ng-schematics:playwright",
+          "options": {
+            "devServerTarget": "marketplace-ui:serve"
+          },
+          "configurations": {
+            "production": {
+              "devServerTarget": "marketplace-ui:serve:production"
+            }
+          }
         }
       }
     }
   },
   "cli": {
-    "analytics": false
+    "analytics": false,
+    "schematicCollections": ["@schematics/angular", "playwright-ng-schematics"]
   },
   "schematics": {
     "@schematics/angular:component": {

--- a/marketplace-ui/e2e/example.spec.ts
+++ b/marketplace-ui/e2e/example.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+  await page.goto('/');
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/MyApp/);
+});

--- a/marketplace-ui/e2e/example.spec.ts
+++ b/marketplace-ui/e2e/example.spec.ts
@@ -1,8 +1,0 @@
-import { expect, test } from '@playwright/test';
-
-test('has title', async ({ page }) => {
-  await page.goto('/');
-
-  // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/MyApp/);
-});

--- a/marketplace-ui/e2e/mock/monitoring.mock.ts
+++ b/marketplace-ui/e2e/mock/monitoring.mock.ts
@@ -1,0 +1,103 @@
+import type { Page } from '@playwright/test';
+import type { Repository, RepositoryPages } from '../../src/app/modules/monitor/github.service';
+import { ALL_ITEMS_PAGE_SIZE } from '../../src/app/shared/constants/common.constant';
+
+function createRepository(index: number): Repository {
+  const repoNumber = index + 1;
+  const repoName = repoNumber === 1 ? 'smart-workflow' : repoNumber === 2 ? 'persistence-utils' : `repo-${repoNumber}`;
+  const htmlUrl = `https://market.axonivy.com/${repoName}`;
+  const baseDate = new Date(Date.UTC(2026, 6, 14, index % 24, 0, 0));
+
+  return {
+    repoName,
+    productId: repoName,
+    htmlUrl,
+    focused: repoNumber <= 2,
+    workflowInformation: [
+      {
+        workflowType: 'CI',
+        lastBuilt: baseDate,
+        conclusion: repoNumber === 2 ? 'failure' : 'success',
+        lastBuiltRunUrl: `${htmlUrl}/ci`,
+        currentWorkflowState: 'active',
+        disabledDate: null
+      },
+      {
+        workflowType: 'DEV',
+        lastBuilt: new Date(baseDate.getTime() + 10 * 60 * 1000),
+        conclusion: 'success',
+        lastBuiltRunUrl: `${htmlUrl}/dev`,
+        currentWorkflowState: 'active',
+        disabledDate: null
+      },
+      {
+        workflowType: 'E2E',
+        lastBuilt: new Date(baseDate.getTime() + 20 * 60 * 1000),
+        conclusion: 'success',
+        lastBuiltRunUrl: `${htmlUrl}/e2e`,
+        currentWorkflowState: 'active',
+        disabledDate: null
+      }
+    ],
+    testResults: [
+      {
+        workflow: 'CI',
+        results: { PASSED: repoNumber + 8, FAILED: repoNumber === 2 ? 1 : 0, SKIPPED: 0 }
+      },
+      {
+        workflow: 'DEV',
+        results: { PASSED: repoNumber + 9, FAILED: 0, SKIPPED: 0 }
+      },
+      {
+        workflow: 'E2E',
+        results: { PASSED: repoNumber + 6, FAILED: 0, SKIPPED: repoNumber % 2 }
+      }
+    ]
+  };
+}
+
+export const MONITORING_REPOSITORIES: Repository[] = Array.from({ length: 25 }, (_, index) => createRepository(index));
+
+function buildMonitoringPage(pageNumber: number, pageSize: number): RepositoryPages {
+  return buildMonitoringPageWithSearch(pageNumber, pageSize, '');
+}
+
+function buildMonitoringPageWithSearch(pageNumber: number, pageSize: number, search: string): RepositoryPages {
+  const normalizedSearch = search.trim().toLowerCase();
+  const filteredRepositories = normalizedSearch
+    ? MONITORING_REPOSITORIES.filter(repo => repo.repoName.toLowerCase().includes(normalizedSearch))
+    : MONITORING_REPOSITORIES;
+  const effectivePageSize = pageSize === ALL_ITEMS_PAGE_SIZE ? MONITORING_REPOSITORIES.length : pageSize;
+  const start = pageNumber * effectivePageSize;
+  const end = start + effectivePageSize;
+  const pagedRepositories = filteredRepositories.slice(start, end);
+
+  return {
+    _embedded: {
+      githubRepos: pagedRepositories
+    },
+    page: {
+      size: effectivePageSize,
+      totalElements: filteredRepositories.length,
+      totalPages: Math.ceil(filteredRepositories.length / effectivePageSize),
+      number: pageNumber
+    }
+  } as RepositoryPages;
+}
+
+export const MONITORING_PAGE = buildMonitoringPage(0, 10);
+
+export async function setupMonitoringApiMocks(page: Page): Promise<void> {
+  await page.route('**/api/monitor-dashboard**', async route => {
+    const url = new URL(route.request().url());
+    const pageNumber = Number(url.searchParams.get('page') ?? '0');
+    const pageSize = Number(url.searchParams.get('size') ?? '10');
+    const search = url.searchParams.get('search') ?? '';
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(buildMonitoringPageWithSearch(pageNumber, pageSize, search))
+    });
+  });
+}

--- a/marketplace-ui/e2e/monitoring.spec.ts
+++ b/marketplace-ui/e2e/monitoring.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+import { MonitoringPage } from './page-objects/MonitoringPage';
+import { MONITORING_REPOSITORIES, setupMonitoringApiMocks } from './mock/monitoring.mock';
+
+test.describe('Monitoring page', () => {
+  test('renders mocked repositories and receives a 200 response', async ({ page }) => {
+    await setupMonitoringApiMocks(page);
+
+    const responsePromise = page.waitForResponse(
+      response => response.url().includes('/api/monitor-dashboard') && response.status() === 200
+    );
+
+    const monitoring = new MonitoringPage(page);
+    await monitoring.goto();
+
+    const response = await responsePromise;
+    expect(response.ok()).toBe(true);
+
+    await monitoring.assertSearchBarVisible();
+    await monitoring.assertModeButtonsVisible();
+    await monitoring.assertPaginationState(10, 3);
+    await monitoring.assertTableRowContainsText(0, /smart-workflow/i);
+    await monitoring.assertTableRowHasLink(0, 'https://market.axonivy.com/smart-workflow');
+    await monitoring.assertTableRowContainsText(1, /persistence-utils/i);
+    await monitoring.assertTableRowHasLink(1, 'https://market.axonivy.com/persistence-utils');
+
+    await monitoring.selectPageSize(20);
+    await monitoring.assertPaginationState(20, 2);
+    await monitoring.assertTableRowContainsText(0, /smart-workflow/i);
+    await monitoring.assertTableRowContainsText(19, /repo-20/i);
+
+    await monitoring.selectPageSize('all');
+    await monitoring.assertPaginationState(MONITORING_REPOSITORIES.length, 1);
+    await monitoring.assertTableRowContainsText(24, /repo-25/i);
+  });
+
+  test('filters repositories when searching for smart', async ({ page }) => {
+    await setupMonitoringApiMocks(page);
+
+    const monitoring = new MonitoringPage(page);
+    await monitoring.goto();
+    await monitoring.assertSearchBarVisible();
+
+    const responsePromise = page.waitForResponse(response => {
+      return response.url().includes('/api/monitor-dashboard/repos') && response.url().includes('search=smart');
+    });
+
+    await monitoring.search('smart');
+    await responsePromise;
+
+    await monitoring.assertTableHasRows(1);
+    await monitoring.assertAllTableRowsContainText(/smart/i);
+  });
+});

--- a/marketplace-ui/e2e/page-objects/MonitoringPage.ts
+++ b/marketplace-ui/e2e/page-objects/MonitoringPage.ts
@@ -1,0 +1,100 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export class MonitoringPage {
+  readonly page: Page;
+  readonly locator: Locator;
+  readonly searchInput: Locator;
+  readonly defaultModeButton: Locator;
+  readonly reportModeButton: Locator;
+  readonly table: Locator;
+  readonly tableRows: Locator;
+  readonly pageSizeSelect: Locator;
+  readonly pagination: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.locator = page.locator('app-monitor-dashboard');
+    this.searchInput = this.locator.locator('input[type="text"].search-input');
+    this.defaultModeButton = this.locator.locator('label[for^="default-mode-"]', { hasText: 'Default Mode' });
+    this.reportModeButton = this.locator.locator('label[for^="report-mode-"]', { hasText: 'Report Mode' });
+    this.table = this.locator.locator('app-monitor-repo .monitor-repo-wrapper > div.position-relative > table.table');
+    this.tableRows = this.table.locator('tbody > tr');
+    this.pageSizeSelect = this.locator.locator('select.form-select.pagination');
+    this.pagination = this.locator.locator('ngb-pagination');
+  }
+
+  async goto() {
+    await this.page.goto('/monitoring');
+    await expect(this.locator).toBeVisible();
+  }
+
+  async search(text: string) {
+    await this.searchInput.fill(text);
+  }
+
+  async selectDefaultMode() {
+    await this.defaultModeButton.click();
+  }
+
+  async selectReportMode() {
+    await this.reportModeButton.click();
+  }
+
+  async assertSearchBarVisible() {
+    await expect(this.searchInput).toBeVisible();
+  }
+
+  async assertModeButtonsVisible() {
+    await expect(this.defaultModeButton).toBeVisible();
+    await expect(this.reportModeButton).toBeVisible();
+  }
+
+  async getTableRowCount(): Promise<number> {
+    return this.tableRows.count();
+  }
+
+  getTableRow(index: number): Locator {
+    return this.tableRows.nth(index);
+  }
+
+  async assertTableRowContainsText(index: number, text: string | RegExp) {
+    await expect(this.getTableRow(index)).toContainText(text);
+  }
+
+  async assertTableRowHasLink(index: number, href: string | RegExp) {
+    await expect(this.getTableRow(index).locator('p.name > a')).toHaveAttribute('href', href);
+  }
+
+  async assertAllTableRowsContainText(text: string | RegExp) {
+    const rowCount = await this.getTableRowCount();
+    for (let index = 0; index < rowCount; index += 1) {
+      await expect(this.getTableRow(index)).toContainText(text);
+    }
+  }
+
+  async assertTableHasAtMostRows(maxRows = 10) {
+    await expect(await this.getTableRowCount()).toBeLessThanOrEqual(maxRows);
+  }
+
+  async assertTableHasRows(expected: number) {
+    await expect(this.tableRows).toHaveCount(expected);
+  }
+
+  async selectPageSize(pageSize: 10 | 20 | 'all') {
+    const optionIndex = pageSize === 10 ? 0 : pageSize === 20 ? 1 : 2;
+    await this.pageSizeSelect.selectOption({ index: optionIndex });
+  }
+
+  async getPaginationPageNumberCount(): Promise<number> {
+    return this.pagination
+      .locator('li .page-link')
+      .evaluateAll(
+        links => links.map(link => link.textContent?.trim() ?? '').filter(text => /^\d+$/.test(text)).length
+      );
+  }
+
+  async assertPaginationState(expectedRows: number, expectedPages: number) {
+    await expect(this.tableRows).toHaveCount(expectedRows);
+    await expect.poll(() => this.getPaginationPageNumberCount()).toBe(expectedPages);
+  }
+}

--- a/marketplace-ui/e2e/tsconfig.json
+++ b/marketplace-ui/e2e/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./**/*.ts"]
+}

--- a/marketplace-ui/package-lock.json
+++ b/marketplace-ui/package-lock.json
@@ -62,6 +62,7 @@
         "@types/markdown-it-emoji": "^3.0.1",
         "@types/node": "^20.19.37",
         "jsdom": "^26.1.0",
+        "playwright-ng-schematics": "^22.0.1",
         "prettier": "^3.7.4",
         "typescript": "~6.0.3",
         "vitest": "^4.1.2"
@@ -8996,6 +8997,23 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/playwright-ng-schematics": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/playwright-ng-schematics/-/playwright-ng-schematics-22.0.1.tgz",
+      "integrity": "sha512-AGPJsCNb2/n03KUFNDRnclNsx/h6Uh2ao6qSUyvo1/MtAIFdvagRm9b+dj99H7ReyrWLRAdTCVTm6SCoCCJI9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@angular-devkit/architect": ">= 0.2200.0 < 0.2300.0",
+        "@angular-devkit/core": "^22.0.0",
+        "@angular-devkit/schematics": "^22.0.0"
+      },
+      "peerDependencies": {
+        "@angular-devkit/architect": ">= 0.2200.0 < 0.2300.0",
+        "@angular-devkit/core": "^22.0.0",
+        "@angular-devkit/schematics": "^22.0.0"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {

--- a/marketplace-ui/package.json
+++ b/marketplace-ui/package.json
@@ -10,7 +10,8 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:real": "E2E_REAL_ENDPOINT=true playwright test --grep @real-endpoint",
-    "serve:ssr:marketplace-ui": "node dist/server/server.mjs"
+    "serve:ssr:marketplace-ui": "node dist/server/server.mjs",
+    "e2e": "ng e2e"
   },
   "private": true,
   "dependencies": {
@@ -68,6 +69,7 @@
     "@types/markdown-it-emoji": "^3.0.1",
     "@types/node": "^20.19.37",
     "jsdom": "^26.1.0",
+    "playwright-ng-schematics": "^22.0.1",
     "prettier": "^3.7.4",
     "typescript": "~6.0.3",
     "vitest": "^4.1.2"

--- a/marketplace-ui/playwright.config.ts
+++ b/marketplace-ui/playwright.config.ts
@@ -10,9 +10,10 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: isCI,
   retries: isCI ? 2 : 0,
-  reporter: [['html', { open: 'never' }]],
+  reporter: [['html', { open: 'never' }], ['list']],
   use: {
     baseURL,
+    headless: false,
     trace: isCI ? 'retain-on-failure' : 'on-first-retry',
     screenshot: isCI ? 'only-on-failure' : 'off',
     video: isCI ? 'retain-on-failure' : 'off'

--- a/marketplace-ui/src/app/modules/monitor/monitor-repo/monitor-repo.component.ts
+++ b/marketplace-ui/src/app/modules/monitor/monitor-repo/monitor-repo.component.ts
@@ -17,12 +17,7 @@ import { CommonModule } from '@angular/common';
 import { LanguageService } from '../../../core/services/language/language.service';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { BuildBadgeTooltipComponent } from '../build-badge-tooltip/build-badge-tooltip.component';
-import {
-  NgbTooltipModule,
-  NgbPagination,
-  NgbPaginationModule,
-  NgbTypeaheadModule
-} from '@ng-bootstrap/ng-bootstrap';
+import { NgbTooltipModule, NgbPagination, NgbPaginationModule, NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
 import { FormsModule } from '@angular/forms';
 import { ProductFilterComponent } from '../../product/product-filter/product-filter.component';
 import { RepoTestResultComponent } from '../repo-test-result/repo-test-result.component';
@@ -102,6 +97,7 @@ export class MonitoringRepoComponent implements OnInit, OnDestroy {
   languageService = inject(LanguageService);
   translateService = inject(TranslateService);
   githubService = inject(GithubService);
+  cdr = inject(ChangeDetectorRef);
   router = inject(Router);
   route = inject(ActivatedRoute);
   platformId = inject(PLATFORM_ID);


### PR DESCRIPTION
This PR isolates the MonitoringPage page object, its mocks, and e2e test into a focused branch.

Files included:
- e2e/page-objects/MonitoringPage.ts
- e2e/mock/monitoring.mock.ts
- e2e/monitoring.spec.ts

Base: develop